### PR TITLE
Fixed the about page bug and fixed layout issues

### DIFF
--- a/BoomRadio/BoomRadio/Components/AboutFrame.xaml
+++ b/BoomRadio/BoomRadio/Components/AboutFrame.xaml
@@ -3,14 +3,15 @@
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
        x:Class="BoomRadio.Components.AboutFrame"
-       Padding="5">
+       Padding="5"
+       HasShadow="True">
     <Frame.Content VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Transparent">
-        <StackLayout x:Name="BackPanel" BackgroundColor="Transparent" VerticalOptions="StartAndExpand" HorizontalOptions="CenterAndExpand">
-                <xct:Expander>
+        <StackLayout x:Name="BackPanel" BackgroundColor="Transparent" VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand">
+                <xct:Expander HorizontalOptions="FillAndExpand" WidthRequest="400">
                     <xct:Expander.Header>
-                        <StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="StartAndExpand">
+                        <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="StartAndExpand" >
                             <Image x:Name="MainImage"/>
-                            <Label x:Name="TitleLabel" Text="Who is BOOM Radio?" Padding="10" FontFamily="CG-B" FontSize="14" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
+                            <Label x:Name="TitleLabel" Text="Who is BOOM Radio?" Padding="10" FontFamily="CG-B" FontSize="18" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
                         </StackLayout>
                     </xct:Expander.Header>
                     <Grid>

--- a/BoomRadio/BoomRadio/MainPage.xaml.cs
+++ b/BoomRadio/BoomRadio/MainPage.xaml.cs
@@ -174,6 +174,11 @@ namespace BoomRadio
             {
                 CloseMenu();
             }
+
+            if(target == "about")
+            {
+                Views["about"] = new AboutView(Sponsor);
+            }
             ContentAreaScrollView.Content = Views[target];
             CurrentView = target;
             (Views[target] as IUpdatableUI)?.UpdateUI();

--- a/BoomRadio/BoomRadio/View/AboutView.xaml
+++ b/BoomRadio/BoomRadio/View/AboutView.xaml
@@ -47,20 +47,24 @@
                             <StackLayout x:Name="SponsorStackLayout" Padding="0" VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Transparent" MinimumHeightRequest="200" MinimumWidthRequest="60">
 
                                 <!--Sponsors Image loads here, out of the expand-->
-                                <Image  Aspect="AspectFit" HeightRequest="350" BackgroundColor="{Binding Source={x:Reference AboutPage}, Path=BgColour}">
-                                    <Image.Source>
-                                        <UriImageSource Uri="{Binding SponsorImageUrl}" CachingEnabled="True" CacheValidity="1"/>
-                                    </Image.Source>
-                                </Image>
+
 
                                 <Frame VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Transparent">
                                     <StackLayout Padding="10" BackgroundColor="{Binding Source={x:Reference AboutPage}, Path=BgColour}" VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand">
                                         <!--Sponsor expand-->
-                                        <Label Text="{Binding SponsorName}" TextColor="{Binding Source={x:Reference AboutPage}, Path=TextColour}" TextType="Html" Padding="10" FontFamily="CG-B" FontSize="14" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
                                             <xct:Expander>
                                                 <xct:Expander.Header>
-                                                <Label Text="Click to read more" Padding="10" FontFamily="CG-r" FontSize="12" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" TextColor="{Binding Source={x:Reference AboutPage}, Path=TextColour}"/>
-                                                </xct:Expander.Header>
+                                                <StackLayout>
+                                                    <Image  Aspect="AspectFit" HeightRequest="350" BackgroundColor="{Binding Source={x:Reference AboutPage}, Path=BgColour}">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding SponsorImageUrl}" CachingEnabled="True" CacheValidity="1"/>
+                                                         </Image.Source>
+                                                    </Image>
+                                                    <Label Text="{Binding SponsorName}" TextColor="{Binding Source={x:Reference AboutPage}, Path=TextColour}" TextType="Html" Padding="10" FontFamily="CG-B" FontSize="18" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
+                                                    <Label Text="Tap to read more" Padding="10" FontFamily="CG-r" FontSize="12" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" TextColor="{Binding Source={x:Reference AboutPage}, Path=TextColour}"/>
+ 
+                                                </StackLayout>
+                                               </xct:Expander.Header>
 
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
-When calling the about page the entire page is now refreshed, fixes the issue with the locking up expanders. 
-Changes to font sizes for each heading within the boxes on the page.
-Moved sponsors image within the expander header to allow user to press image to expand information. 