### PR TITLE
Fix the application of dark mode after opening

### DIFF
--- a/BoomRadio/BoomRadio/MainPage.xaml.cs
+++ b/BoomRadio/BoomRadio/MainPage.xaml.cs
@@ -56,6 +56,20 @@ namespace BoomRadio
             Navigate("home");
             UpdateUI();
             UpdatePlayerUIs();
+            // Handle changes to device theme (dark/light mode)
+            Xamarin.Forms.Application.Current.RequestedThemeChanged += RequestedThemeChanged;
+        }
+
+        /// <summary>
+        /// Handles changes to the requested theme (device dark/light mode) 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        private void RequestedThemeChanged(object sender, AppThemeChangedEventArgs args)
+        {
+            Theme.UpdateFromPreferences();
+            UpdateUI();
+            UpdatePlayerColours();
         }
 
         protected override void OnAppearing()

--- a/BoomRadio/BoomRadio/Model/Theme.cs
+++ b/BoomRadio/BoomRadio/Model/Theme.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 
 namespace BoomRadio.Model
@@ -11,6 +12,11 @@ namespace BoomRadio.Model
         private static Dictionary<string, Color> darkModeColors = new Dictionary<string, Color>();
 
         public static bool UseDarkMode { get; set; } = false;
+
+        // Key names for storing theme/settings in preferences 
+        public static string DarkModeKey { get; } = "darkMode";
+        public static string DeviceDarkModeKey { get; } = "deviceDarkMode";
+        public static string AutoplayKey { get; } = "autoplay";
 
         static Theme()
         {
@@ -32,6 +38,17 @@ namespace BoomRadio.Model
             darkModeColors["is-live"] = Color.FromHex("f95454");
             darkModeColors["accent"] = Color.FromHex("F3712A");
             darkModeColors["highlight"] = Color.FromHex("F27405");
+            UpdateFromPreferences();
+
+            // Check if dark mode should be applied
+            if (Preferences.Get(DeviceDarkModeKey, false))
+            {
+                UseDarkMode = Application.Current.RequestedTheme == OSAppTheme.Dark;
+            }
+            else
+            {
+                UseDarkMode = Preferences.Get(DarkModeKey, false);
+            }
         }
 
         /// <summary>
@@ -42,6 +59,21 @@ namespace BoomRadio.Model
         public static Color GetColour(string name)
         {
             return (UseDarkMode ? darkModeColors : lightModeColors)[name];
+        }
+
+        /// <summary>
+        /// Updates the theme to use dark/light mode based on the saved preference
+        /// </summary>
+        public static void UpdateFromPreferences()
+        {
+            if (Preferences.Get(DeviceDarkModeKey, false))
+            {
+                UseDarkMode = Application.Current.RequestedTheme == OSAppTheme.Dark;
+            }
+            else
+            {
+                UseDarkMode = Preferences.Get(DarkModeKey, false);
+            }
         }
     }
 }

--- a/BoomRadio/BoomRadio/View/SettingsView.xaml.cs
+++ b/BoomRadio/BoomRadio/View/SettingsView.xaml.cs
@@ -9,10 +9,6 @@ namespace BoomRadio.View
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class SettingsView : StackLayout, IUpdatableUI
     {
-        // Keys used to store preferences
-        readonly string darkModeKey = "darkMode";
-        readonly string deviceDarkModeKey = "deviceDarkMode";
-        readonly string autoplayKey = "autoplay";
         MainPage MainPage;
 
         public SettingsView(MainPage mainPage)
@@ -20,7 +16,6 @@ namespace BoomRadio.View
             InitializeComponent();
             MainPage = mainPage;
             UpdateTheme();
-            Application.Current.RequestedThemeChanged += (sender, args) => UpdateTheme();
             
         }
 
@@ -29,14 +24,7 @@ namespace BoomRadio.View
         /// </summary>
         public void UpdateTheme()
         {
-            if (Preferences.Get(deviceDarkModeKey, false))
-            {
-                Theme.UseDarkMode = Application.Current.RequestedTheme == OSAppTheme.Dark;
-            }
-            else
-            {
-                Theme.UseDarkMode = Preferences.Get(darkModeKey, false);
-            }
+            Theme.UpdateFromPreferences();
             UpdateUI();
             MainPage.UpdateUI();
             MainPage.UpdatePlayerColours();
@@ -48,9 +36,9 @@ namespace BoomRadio.View
         public void UpdateUI()
         {
             // Toggle switches to the saved preference values, or off by default
-            DarkModeSwitch.IsToggled = Preferences.Get(darkModeKey, false);
-            DeviceDarkModeSwitch.IsToggled = Preferences.Get(deviceDarkModeKey, false);
-            AutoplaySwitch.IsToggled = Preferences.Get(autoplayKey, false);
+            DarkModeSwitch.IsToggled = Preferences.Get(Theme.DarkModeKey, false);
+            DeviceDarkModeSwitch.IsToggled = Preferences.Get(Theme.DeviceDarkModeKey, false);
+            AutoplaySwitch.IsToggled = Preferences.Get(Theme.AutoplayKey, false);
             // Disable darm mode toggle if using device mode
             if (DeviceDarkModeSwitch.IsToggled)
             {
@@ -77,7 +65,7 @@ namespace BoomRadio.View
         /// <param name="e"></param>
         private void DarkModeSwitch_Toggled(object sender, ToggledEventArgs e)
         {
-            Preferences.Set(darkModeKey, e.Value);
+            Preferences.Set(Theme.DarkModeKey, e.Value);
             UpdateTheme();
         }
 
@@ -88,7 +76,7 @@ namespace BoomRadio.View
         /// <param name="e"></param>
         private void DeviceDarkModeSwitch_Toggled(object sender, ToggledEventArgs e)
         {
-            Preferences.Set(deviceDarkModeKey, e.Value);
+            Preferences.Set(Theme.DeviceDarkModeKey, e.Value);
             UpdateTheme();
         }
 
@@ -97,7 +85,7 @@ namespace BoomRadio.View
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void AutoplaySwitch_Toggled(object sender, ToggledEventArgs e) => Preferences.Set(autoplayKey, e.Value);
+        private void AutoplaySwitch_Toggled(object sender, ToggledEventArgs e) => Preferences.Set(Theme.AutoplayKey, e.Value);
 
         public async void SetHorizontalDisplay()
         {


### PR DESCRIPTION
Logic moved out of SettingsView code-behind, since that has lazy
instantiation and won't load until the settings page is opened.

Fixes #43 