### PR TITLE
Fix live track details and artwork

### DIFF
--- a/BoomRadio/BoomRadio/Model/Track.cs
+++ b/BoomRadio/BoomRadio/Model/Track.cs
@@ -17,6 +17,10 @@ namespace BoomRadio
         public string Title { get; set; } = "Not Just Noise";
         public string ImageUri { get; set; } = "https://cdn-radiotime-logos.tunein.com/s195836q.png";
 
+        public static string defaultArtist { get; } = "BOOM Radio";
+        public static string defaultTitle { get; } = "Not Just Noise";
+        public static string defaultImageUri { get; } = "https://cdn-radiotime-logos.tunein.com/s195836q.png";
+
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
- Get track details from the streaming server's metadata, now that it
has been fixed on the server.
- Get cover art, when available, by searching MusicBrainz APIs